### PR TITLE
Docker for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,6 @@ jobs:
     - name: Install package requirements
       run: apt-get install -y make git build-essential binutils-mips-linux-gnu gcc-mips-linux-gnu python3 python3-pip python3-venv clang-format-14 clang-tidy-14
 
-    - name: Install Python dependencies
-      run: pip3 install -r requirements.txt
-
     - name: Get the dependency
       run: cp /orig/${{ matrix.version }}/baserom.z64 baseroms/${{ matrix.version }}/baserom.z64
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,15 @@
 name: Build
 
 # Build on every branch push, tag push, and pull request change:
-on: [push, pull_request_target]
+on:
+  push:
+  pull_request:
 
 jobs:
   build_repo:
+    # This is a *private* build container.
+    container: ghcr.io/decompals/yoshis-story-build:main
+
     name: Build repo
     runs-on: ubuntu-latest
 
@@ -15,24 +20,18 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
 
     - name: Install package requirements
-      run: sudo apt-get install -y make git build-essential clang binutils-mips-linux-gnu gcc-mips-linux-gnu python3 python3-pip clang-format-14 clang-tidy-14
+      run: apt-get install -y make git build-essential binutils-mips-linux-gnu gcc-mips-linux-gnu python3 python3-pip python3-venv clang-format-14 clang-tidy-14
 
     - name: Install Python dependencies
       run: pip3 install -r requirements.txt
 
-    - name: Get extra dependencies
-      uses: actions/checkout@v4
-      with:
-        repository: ${{ secrets.SECRETREPO }}
-        token: ${{ secrets.SECRETTOKEN }}
-        path: deps_repo
     - name: Get the dependency
-      run: cp deps_repo/yoshis-story/* baseroms/us/baserom.z64
+      run: cp /orig/${{ matrix.version }}/baserom.z64 baseroms/${{ matrix.version }}/baserom.z64
 
     - name: venv
       run: make venv -j $(nproc) VERSION=${{ matrix.version }}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ The build process has the following package requirements:
 * make
 * git
 * build-essential
-* clang
 * binutils-mips-linux-gnu
 * python3
 * pip3
@@ -26,7 +25,7 @@ Under Debian / Ubuntu (which we recommend using), you can install them with the 
 
 ```bash
 sudo apt update
-sudo apt install make git build-essential clang binutils-mips-linux-gnu python3 python3-pip
+sudo apt install make git build-essential binutils-mips-linux-gnu python3 python3-pip python3-venv
 ```
 
 #### 2. Install python dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-splat64[mips]>=0.32.1,<1.0.0
+splat64[mips]==0.32.1
+spimdisasm==1.31.0
+rabbitizer==1.10.0
 mapfile-parser>=2.3.5,<3.0.0
 
 # asm-differ

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 splat64[mips]==0.32.1
 spimdisasm==1.31.0
-rabbitizer==1.10.0
+rabbitizer==1.12.0
 mapfile-parser>=2.3.5,<3.0.0
 
 # asm-differ


### PR DESCRIPTION
Introduces a docker based approach to get the stuff needed to build the repo in CI, instead of using GHA secrets and `pull_request_target` to get PRs to work as intended.

`pull_request_target` is not desirable because it is a pain to work with and it opens the door for bad actors to attack a repository and steal secrets.

This approach is documented here https://github.com/encounter/dtk-template/blob/main/docs/github_actions.md . Thanks a lot for the GC/Wii community and Encounter for the idea.

The n64 adaptation of this idea was taken from here https://github.com/AngheloAlf/drmario64/pull/19